### PR TITLE
the firedancer config entry has changed from [development.net] to [net]

### DIFF
--- a/docs/connect.md
+++ b/docs/connect.md
@@ -59,7 +59,7 @@
 - Solana CLI (optional)
 - If you are running Firedancer, you will need to add the following to your `config.toml` file on version v0.502.20212 or higher. (No additional configuration is required for Agave and Jito.)
 ```
-[development.net]
+[net]
     provider = "socket"
 ```
 


### PR DESCRIPTION
Deprecated:
```
[development.net]
    provider = "socket"
```

Current:
```
[net]
    provider = "socket"
```

I can confirm this change works.
After the recent (May 6, 2025 15:00:00 UTC) DoubleZero TestNet upgrade, i noticed my Validator started behaving as such :
- Egress was 0 Mb/s
- Leader Schedule > My Slots was Skipping ( 8 slots )
- My logs showed that the config was incorrect

Here is validator on Firedancer GUI [ibrl-test-fd](http://fd-test.ibrl.top/)
Hers is validator on Validators App [ibrl-test-va](https://www.validators.app/validators/dzkLmvHKsScz186ZAvnXMyHCeRznFrKyX7pzbozbz4T?locale=en&network=testnet)

<img width="1054" alt="ibrl-test-recent-block-production" src="https://github.com/user-attachments/assets/6986f69f-d4d8-42bc-b723-6784c38b708d" />



Reference:
[Docs-Firedancer-Configuring](https://docs.firedancer.io/guide/configuring.html)