### PR TITLE
docs: fix path to iproute2

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -277,7 +277,7 @@ Use these steps if your DoubleZero Agent will connect to the DoubleZero Controll
     ! Replace the word "default" with the VRF name identified in prerequisites step 4
     !
     daemon doublezero-agent
-    exec ip netns exec ns-default /usr/local/bin/doublezero-agent -pubkey <PUBKEY>
+    exec /sbin/ip netns exec ns-default /usr/local/bin/doublezero-agent -pubkey <PUBKEY>
     no shut
     ```
     b. Verify that the agent is working


### PR DESCRIPTION
Contributors are getting the following error when attempting to configure the config agent because we're not including the full path to the iproute2 binary in the docs:
```
exec ip netns exec ns-default /usr/local/bin/doublezero-agent -pubkey 23oq2VMcTUoZ45vbdfGU6wRpfdsNdGhj1jLRGKxzq27K
! The executable ip does not exist (or is not executable)
```