### PR TITLE
docs: add geolocation user and contributor documentation (#165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 
 .devcontainer/
 smartcontract/.vscode/settings.json
+site/

--- a/docs/Edge Subscriber Connection.md
+++ b/docs/Edge Subscriber Connection.md
@@ -9,6 +9,8 @@ Install the [Solana CLI](https://docs.anza.xyz/cli/install).
 
 Follow the [setup](setup.md) instructions to install and configure the DoubleZero client.
 
+If you have previously setup DoubleZero, ensure you have the latest Doublezero-Solana CLI with `sudo apt update && sudo apt install doublezero-solana`
+
 ### 2. Configure the Firewall
 
 Allow GRE, BGP, PIM, and shred traffic.
@@ -95,7 +97,7 @@ Before buying a seat, identify the device with the lowest latency from your mach
 doublezero latency
 ```
 
-Note the device code from the lowest-latency result (e.g., `MIA-1`). You'll use this when purchasing a seat.
+Note the device code from the lowest-latency result (e.g., `<Device_Name>`). You'll use this when purchasing a seat.
 
 ### 2. Check Pricing
 
@@ -110,7 +112,7 @@ doublezero-solana shreds price
 **Specific device:**
 
 ```bash
-doublezero-solana shreds price --device-code MIA-1
+doublezero-solana shreds price --device-code <Device_Name>
 doublezero-solana shreds price --device <PUBKEY>
 ```
 
@@ -130,9 +132,9 @@ Purchase a seat with a single command. This initializes your seat, funds the esc
 
 ```bash
 doublezero-solana shreds pay \
-  --device-code MIA-1 \
-  --client-ip 203.0.113.42 \
-  --amount 100
+  --device-code <Device_Name> \
+  --client-ip <Target_IP> \
+  --amount <Cost_Of_Seat>
 ```
 
 **Parameters:**
@@ -140,7 +142,7 @@ doublezero-solana shreds pay \
 | Flag | Description |
 |------|-------------|
 | `--device <PUBKEY>` | Target device by public key (mutually exclusive with `--device-code`) |
-| `--device-code <CODE>` | Target device by human-readable code (e.g., `MIA-1`) |
+| `--device-code <CODE>` | Target device by human-readable code (e.g., `<Device_Name>`) |
 | `--client-ip <IP>` | Your machine's public IPv4 address |
 | `--amount <USDC>` | USDC to fund (decimal format, e.g. `100` = 100 USDC). Must meet the minimum epoch price. |
 | `--source-token-account <PUBKEY>` | Custom USDC source account (defaults to your wallet's ATA) |
@@ -173,10 +175,12 @@ To top up your escrow, run `shreds pay` again at any time:
 
 ```bash
 doublezero-solana shreds pay \
-  --device-code MIA-1 \
-  --client-ip 203.0.113.42 \
+  --device-code <Device_Name> \
+  --client-ip <Target_IP> \
   --amount 500
 ```
+
+Note that the `Target_IP` must be a public ipv4 address on the machine which will be receiving shreds. You can find this by running a command like `curl -4 ifconfig.me` on the target machine.
 
 ### Monitor Seats
 
@@ -191,13 +195,13 @@ doublezero-solana shreds list
 **Filter by device:**
 
 ```bash
-doublezero-solana shreds list --device-code MIA-1
+doublezero-solana shreds list --device-code <Device_Name>
 ```
 
 **Filter by client IP:**
 
 ```bash
-doublezero-solana shreds list --client-ip 203.0.113.42
+doublezero-solana shreds list --client-ip <Target_IP>
 ```
 
 **Filter by wallet:**
@@ -216,8 +220,8 @@ Close your escrow and refund remaining USDC to your wallet:
 
 ```bash
 doublezero-solana shreds withdraw \
-  --device-code MIA-1 \
-  --client-ip 203.0.113.42
+  --device-code <Device_Name> \
+  --client-ip <Target_IP>
 ```
 
 You can identify the device by either `--device <PUBKEY>` or `--device-code <CODE>`, same as other commands.
@@ -226,8 +230,8 @@ To send the refund to a different token account:
 
 ```bash
 doublezero-solana shreds withdraw \
-  --device-code MIA-1 \
-  --client-ip 203.0.113.42 \
+  --device-code <Device_Name> \
+  --client-ip <Target_IP> \
   --refund-token-account <PUBKEY>
 ```
 

--- a/docs/Edge Subscriber Connection.md
+++ b/docs/Edge Subscriber Connection.md
@@ -1,0 +1,305 @@
+# Edge Subscriber Connection
+!!! warning "By connecting to DoubleZero I agree to the [DoubleZero Terms of Use](https://doublezero.xyz/terms-protocol). Please note that the data is for your internal purposes only and may not be retransmitted (see Section 2(e))."
+
+## Step 1: DoubleZero Setup
+
+### 1. Complete Setup
+
+Install the [Solana CLI](https://docs.anza.xyz/cli/install).
+
+Follow the [setup](setup.md) instructions to install and configure the DoubleZero client.
+
+### 2. Configure the Firewall
+
+Allow GRE, BGP, PIM, and shred traffic.
+
+**iptables:**
+
+```bash
+sudo iptables -A OUTPUT -p gre -j ACCEPT
+sudo iptables -A INPUT -i doublezero1 -s 169.254.0.0/16 -d 169.254.0.0/16 -p tcp --dport 179 -j ACCEPT
+sudo iptables -A OUTPUT -o doublezero1 -s 169.254.0.0/16 -d 169.254.0.0/16 -p tcp --dport 179 -j ACCEPT
+sudo iptables -A OUTPUT -o doublezero1 -p pim -j ACCEPT
+sudo iptables -A INPUT -i doublezero1 -p udp --dport 7733 -j ACCEPT
+sudo iptables -A INPUT -i doublezero0 -p udp --dport 44880 -j ACCEPT
+```
+
+**UFW:**
+
+```bash
+sudo ufw allow proto gre from any to any
+sudo ufw allow in on doublezero1 from 169.254.0.0/16 to 169.254.0.0/16 port 179 proto tcp
+sudo ufw allow out on doublezero1 from 169.254.0.0/16 to 169.254.0.0/16 port 179 proto tcp
+sudo ufw allow out on doublezero1 proto pim from any to any
+sudo ufw allow in on doublezero1 to any port 7733 proto udp
+sudo ufw allow in on doublezero0 to any port 44880 proto udp
+```
+
+### 3. Enable the Reconciler
+
+The reconciler monitors onchain state and automatically provisions tunnels when your seat is allocated. It is not enabled by default.
+
+```bash
+doublezero enable
+```
+
+### 4. Retrieve the Server's DoubleZero Identity
+
+Review your DoubleZero Identity. This identity will be used to create the connection between your machine and DoubleZero.
+
+```bash
+doublezero address
+```
+
+**Output:**
+```
+YourDoubleZeroAddress11111111111111111111111111111
+```
+
+---
+
+## Step 2: Set Up Your Wallet
+
+### 1. Create a Solana Keypair
+
+The `doublezero-solana` CLI uses a standard Solana keypair for onchain seat management. If you don't have one:
+
+```bash
+solana-keygen new
+```
+
+This writes to `~/.config/solana/id.json`. To use a different path, pass `--keypair <path>` to any `doublezero-solana` command.
+
+Print your wallet address:
+
+```bash
+solana address
+```
+
+### 2. Fund Your Wallet
+
+Your wallet needs two tokens:
+
+- **SOL** — for Solana transaction fees. Transfer SOL to the wallet address printed above.
+- **USDC** — for seat funding. The CLI pulls from your wallet's Associated Token Account (ATA) for the mainnet USDC mint (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`).
+
+---
+
+## Step 3: Buy a Seat
+
+### 1. Find Your Nearest Device
+
+Before buying a seat, identify the device with the lowest latency from your machine:
+
+```bash
+doublezero latency
+```
+
+Note the device code from the lowest-latency result (e.g., `MIA-1`). You'll use this when purchasing a seat.
+
+### 2. Check Pricing
+
+View current device pricing before committing funds. Pricing has two components: a **base metro price** and a **per-device premium**. Prices update each epoch. You can also view pricing and availability [here](https://data.malbeclabs.com/dz/shreds/devices).
+
+**All devices:**
+
+```bash
+doublezero-solana shreds price
+```
+
+**Specific device:**
+
+```bash
+doublezero-solana shreds price --device-code MIA-1
+doublezero-solana shreds price --device <PUBKEY>
+```
+
+**All devices in a metro:**
+
+```bash
+doublezero-solana shreds price --metro <PUBKEY>
+```
+
+Output columns: `Device Code`, `Metro Code`, `Metro Name`, `Status`, `Settled Seats`, `Available Seats`, `Base Price (USDC)`, `Premium (USDC)`, `Epoch Price (USDC)`.
+
+The epoch price is the total cost per epoch for a seat on that device (base + premium). Use `--wide` to show full pubkeys, or `--json` for JSON output.
+
+### 3. Buy a Seat
+
+Purchase a seat with a single command. This initializes your seat, funds the escrow, and requests allocation:
+
+```bash
+doublezero-solana shreds pay \
+  --device-code MIA-1 \
+  --client-ip 203.0.113.42 \
+  --amount 100
+```
+
+**Parameters:**
+
+| Flag | Description |
+|------|-------------|
+| `--device <PUBKEY>` | Target device by public key (mutually exclusive with `--device-code`) |
+| `--device-code <CODE>` | Target device by human-readable code (e.g., `MIA-1`) |
+| `--client-ip <IP>` | Your machine's public IPv4 address |
+| `--amount <USDC>` | USDC to fund (decimal format, e.g. `100` = 100 USDC). Must meet the minimum epoch price. |
+| `--source-token-account <PUBKEY>` | Custom USDC source account (defaults to your wallet's ATA) |
+| `--accept-partial-epoch` | Skip the epoch-remaining warning (see below) |
+| `--fee-payer <PATH>` | Use a different wallet for SOL transaction fees |
+| `--dry-run` | Simulate the transaction without executing it |
+| `--with-compute-unit-price <PRICE>` | Set a compute unit price for faster inclusion during congestion |
+
+Once your seat is allocated, the daemon establishes the GRE tunnel automatically. Check your connection with:
+
+```bash
+doublezero status
+```
+
+### Epoch Timing
+
+Seats are allocated per Solana epoch (~2 days). If less than 10% of the current epoch remains when you pay, the CLI warns that your seat will be allocated immediately but only covers the remainder of the current epoch. A separate payment will be deducted from your escrow when the next epoch begins.
+
+!!! info "It is advisable to fund for more than 1 epoch at a time so you don't lose your seat. You can check the current time left in an epoch [here](https://explorer.solana.com/)."
+
+You can bypass this warning with `--accept-partial-epoch`.
+
+### Keep Your Escrow Funded
+
+!!! warning "If your escrow balance is below the epoch price at settlement, your seat will not be allocated, the tunnel will be torn down, and you lose your accumulated tenure. Tenure determines your priority for future epochs — losing it means you compete as a newcomer again."
+
+You may overfund this account to fund multiple epochs. Each settlement deducts one epoch's price from your escrow, and the remaining balance carries forward. For example, funding 5x the per-epoch price keeps your seat active for up to 5 epochs without re-funding.
+
+To top up your escrow, run `shreds pay` again at any time:
+
+```bash
+doublezero-solana shreds pay \
+  --device-code MIA-1 \
+  --client-ip 203.0.113.42 \
+  --amount 500
+```
+
+### Monitor Seats
+
+View your active seats and escrow balances:
+
+**All your seats:**
+
+```bash
+doublezero-solana shreds list
+```
+
+**Filter by device:**
+
+```bash
+doublezero-solana shreds list --device-code MIA-1
+```
+
+**Filter by client IP:**
+
+```bash
+doublezero-solana shreds list --client-ip 203.0.113.42
+```
+
+**Filter by wallet:**
+
+```bash
+doublezero-solana shreds list --withdraw-authority <PUBKEY>
+```
+
+Output columns: `Device Code`, `Client IP`, `Tenure`, `Balance (USDC)`, `Est. Epochs Paid`.
+
+The "Est. Epochs Paid" column shows how many epochs your current balance covers at current pricing. If prices change, this estimate adjusts.
+
+### Withdraw Funds
+
+Close your escrow and refund remaining USDC to your wallet:
+
+```bash
+doublezero-solana shreds withdraw \
+  --device-code MIA-1 \
+  --client-ip 203.0.113.42
+```
+
+You can identify the device by either `--device <PUBKEY>` or `--device-code <CODE>`, same as other commands.
+
+To send the refund to a different token account:
+
+```bash
+doublezero-solana shreds withdraw \
+  --device-code MIA-1 \
+  --client-ip 203.0.113.42 \
+  --refund-token-account <PUBKEY>
+```
+
+!!! warning "Withdrawing means you lose your seat and accumulated tenure."
+
+---
+
+## Expected Port
+
+Leader Shreds and high-stake Retransmit Shreds will arrive over port `7733`, over the `doublezero1` interface. The `doublezero0` interface is for unicast traffic. Port `5765` is a heartbeat monitor from the shred publishers — this will not contain shreds.
+
+## GRE Tunnel Header — XDP
+
+!!! note "Shred traffic delivered over the network is GRE-encapsulated. You may need to strip the GRE header before feeding data into your existing pipeline (e.g. an XDP-based deshredder)."
+
+---
+
+## Tools and Dashboards
+
+### [Edge Scoreboard](https://data.malbeclabs.com/dz/shreds/scoreboard)
+
+Scoreboard benchmarks shred delivery speed across DoubleZero Edge and other providers, using slot-level data to compare performance in real time. Use this dashboard to see a view of Edge shreds win rates against other providers. You can view results for leader shreds only, in addition to full feed comparison. You can also drill down by region to see expected performance.
+
+### [Edge Publishers](https://data.malbeclabs.com/dz/shreds/publishers)
+
+The "Publishing Shreds" metric at the top left of the dashboard shows the total percent of stake weight of all Solana validators publishing leader shreds on DoubleZero Edge. You can see details for each publisher on the network.
+
+### [Edge Subscribers, Devices and Activity](https://data.malbeclabs.com/dz/shreds/subscribers)
+
+You can easily search your Client IP on this page for subscribed seats and view status. Click through specific seat subscriptions to view payment history and activity. You can also view available devices on the [Devices](https://data.malbeclabs.com/dz/shreds/devices) page and all recent activity on the [Activity](https://data.malbeclabs.com/dz/shreds/activity) page.
+
+---
+
+## Troubleshooting
+
+If you run into an issue not covered here, please reach out over your existing channel before working around it. If you do not have a channel, please search [Discord](https://discord.gg/U2fEb4Jq) and open a ticket if required.
+
+### Ensure your Client is up to date:
+
+Run: `sudo apt update && sudo apt install doublezero-solana`
+
+### Insufficient escrow balance
+
+If your escrow balance is below the epoch price at settlement, the seat is not allocated, the tunnel is torn down, and tenure is lost. Top up with `shreds pay` before the next settlement.
+
+### Seat not allocated after paying
+
+- You may have paid late in the epoch — the seat takes effect next epoch.
+- All seats on the device may be taken by higher-tenure incumbents. Check available seats with `shreds price`.
+- If you withdrew before settlement, the seat was not eligible.
+
+### Tunnel not coming up
+
+1. Verify the daemon is running: `sudo systemctl status doublezerod`
+2. Verify the reconciler is enabled: `doublezero enable`
+3. Verify firewall rules are in place (GRE, BGP, PIM, shred traffic on `doublezero1`, port 44880 on `doublezero0`)
+4. Verify your seat is active for the current epoch: `doublezero-solana shreds list`
+5. Check your connection status: `doublezero status`
+
+The daemon's client IP is auto-discovered from your host's public IP — verify it matches the `--client-ip` used in your seat commands.
+
+### Epoch warning prompt
+
+The CLI warns when less than 10% of the epoch remains. Your options:
+
+- Accept with `--accept-partial-epoch` if you want the seat immediately
+- Wait for the next epoch to get a full epoch's coverage
+
+### "Amount is below the current price"
+
+The `pay` command validates your amount against the minimum epoch price (metro base + device premium). Use `shreds price` to check current pricing and increase your amount.
+
+### "Multicast user already exists"
+
+You already have an active subscription through a different path. Disconnect first with `doublezero disconnect`, then retry `shreds pay`.

--- a/docs/contribute-geolocation.md
+++ b/docs/contribute-geolocation.md
@@ -1,0 +1,177 @@
+# Geoprobe Deployment
+
+This guide covers deploying and configuring **geoProbe agents** — the bare metal servers that perform latency measurements for the DoubleZero [Geolocation](geolocation.md) service.
+
+A geoProbe sits between [DZDs](glossary.md#dzd-doublezero-device) and target devices in the three-tier measurement chain. It receives signed LocationOffsets from parent DZDs and measures [RTT](glossary.md#rtt-round-trip-time) to registered targets via [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol), signed TWAMP, or ICMP echo. Each geoProbe is registered onchain and linked to one or more parent DZDs.
+
+For an overview of the geolocation architecture and measurement flows, see the [Geolocation user guide](geolocation.md).
+
+---
+
+## Prerequisites
+
+!!! warning "DZD Telemetry Agent Version"
+    Parent DZDs must run **device telemetry agent version 0.17.0 or newer** to support the geolocation service. Earlier versions do not include the probe discovery, TWAMP pinging, and offset-publishing extensions required for geolocation. Verify agent versions before deploying a probe — a probe paired with an older DZD will not receive offsets.
+
+Before deploying a geoProbe, ensure you have:
+
+- **Bare metal Linux server** — VMs add unpredictable latency to measurements
+- **Network proximity to a DZD** — less than 1ms RTT between the probe and its parent DZD
+- **`CAP_NET_RAW` capability** for the agent process (required for ICMP echo probing with raw sockets)
+- **Ed25519 keypair** for the probe's signing identity
+- **Foundation authorization** — probe registration is foundation-gated; coordinate with [DZF](glossary.md#dzf-doublezero-foundation) before proceeding
+- **Parent DZD(s)** running telemetry agent v0.17.0+
+
+---
+
+## Installation
+
+Install both the agent daemon and the management CLI:
+
+```bash
+sudo apt install doublezero-geoprobe-agent doublezero-geolocation
+```
+
+| Package | Purpose |
+|---------|---------|
+| `doublezero-geoprobe-agent` | Agent daemon that runs on the probe server, performing latency measurements and generating signed offsets |
+| `doublezero-geolocation` | CLI tool used for probe registration and management commands |
+
+---
+
+## Onchain Registration
+
+Probe registration requires foundation authorization. Coordinate with DZF before proceeding.
+
+### Step 1: Register the probe
+
+```bash
+doublezero-geolocation probe create \
+  --env testnet \
+  --code <probe-code> \
+  --exchange <exchange-pubkey> \
+  --public-ip <probe-ip> \
+  --location-offset-port 8923 \
+  --metrics-publisher-pk <signing-key-pubkey>
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `--code` | Unique identifier for the probe (e.g., `ams-tn-gp1`) — max 32 characters |
+| `--exchange` | Public key of the Serviceability Exchange account this probe is associated with |
+| `--public-ip` | Public IPv4 address where the probe listens |
+| `--location-offset-port` | UDP port for receiving LocationOffsets from DZDs (default: 8923) |
+| `--metrics-publisher-pk` | Public key used to sign offsets and telemetry |
+
+### Step 2: Link parent DZDs
+
+```bash
+doublezero-geolocation probe add-parent \
+  --env testnet \
+  --probe <probe-code> \
+  --device <dzd-pubkey>
+```
+
+Each parent DZD must be an activated device in the Serviceability Program. DZDs auto-discover child probes every 60 seconds — once linked, the DZD begins TWAMP measurements and offset generation automatically.
+
+---
+
+## Running the Agent
+
+```bash
+doublezero-geoprobe-agent \
+  --keypair /etc/geoprobe/keypair.json \
+  --geoprobe-pubkey <probe-onchain-pubkey> \
+  --env testnet
+```
+
+### Required Flags
+
+| Flag | Description |
+|------|-------------|
+| `--keypair` | Path to the Ed25519 keypair file for signing offsets |
+| `--geoprobe-pubkey` | The probe's [onchain](glossary.md#onchain) public key (from `probe create`) |
+| `--env` | Network environment: `testnet`, `devnet`, or `mainnet-beta` (sets the ledger RPC URL) |
+
+Alternatively, use `--ledger-rpc-url` instead of `--env` to specify a custom Solana RPC endpoint.
+
+### Optional Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--twamp-listen-port` | 8925 | Port for TWAMP measurements from parent DZDs |
+| `--signed-twamp-port` | 8924 | Port for signed TWAMP probes from inbound targets |
+| `--udp-listen-port` | 8923 | Port for receiving LocationOffset datagrams from DZDs |
+| `--probe-interval` | 30s | How often to measure each target |
+| `--max-offset-age` | 1h | Maximum age of a cached DZD offset before it is discarded |
+| `--verify-interval` | 29s | How often to re-verify target assignments from the ledger |
+| `--verbose` | false | Enable verbose logging |
+| `--metrics-enable` | false | Enable Prometheus metrics endpoint |
+| `--metrics-addr` | — | Address for the Prometheus metrics endpoint (e.g., `0.0.0.0:9090`) |
+
+---
+
+## Ports and Firewall
+
+The geoprobe agent requires several ports open:
+
+| Port | Protocol | Direction | Purpose |
+|------|----------|-----------|---------|
+| 8923/udp | UDP | Inbound from DZDs | Receives signed LocationOffset datagrams |
+| 8924/udp | UDP | Inbound from targets | Signed TWAMP reflector (inbound probe flow) |
+| 8925/udp | UDP | Inbound from DZDs | TWAMP measurements from parent DZDs |
+| ICMP | ICMP | Outbound to targets | ICMP echo requests for OutboundIcmp targets |
+
+!!! note
+    The agent also needs outbound UDP to targets for TWAMP probing (outbound flow) and for delivering signed LocationOffset results to targets.
+
+---
+
+## Monitoring
+
+Enable the Prometheus metrics endpoint for operational visibility:
+
+```bash
+doublezero-geoprobe-agent \
+  --keypair /etc/geoprobe/keypair.json \
+  --geoprobe-pubkey <probe-onchain-pubkey> \
+  --env testnet \
+  --metrics-enable \
+  --metrics-addr 0.0.0.0:9090
+```
+
+Key metrics to monitor:
+
+- **Probe availability** — uptime of the agent process
+- **DZD-to-Probe latency** — should be less than 1ms; higher values indicate a placement problem
+- **Active targets** — number of targets the probe is currently measuring
+- **Signature verification failures** — non-zero values may indicate key misconfiguration or tampered packets
+- **Offset cache hit rate** — a low hit rate means the probe is frequently waiting for fresh DZD offsets
+
+See the [Operations guide](contribute-operations.md#monitoring) for general guidance on Prometheus scraping and alerting patterns used across DoubleZero agents.
+
+---
+
+## Probe Management Commands
+
+The `doublezero-geolocation` CLI provides the following subcommands for managing probes:
+
+| Subcommand | Description |
+|------------|-------------|
+| `probe create` | Register a new geoProbe onchain |
+| `probe get` | Get details of a specific probe by code |
+| `probe list` | List all registered probes |
+| `probe update` | Update probe configuration (IP, port, signing key) |
+| `probe delete` | Delete a probe (requires no active target references) |
+| `probe add-parent` | Link a parent DZD to the probe |
+| `probe remove-parent` | Remove a parent DZD from the probe |
+
+All subcommands accept `--env` or `--rpc-url` to select the network. Write operations (`create`, `update`, `delete`, `add-parent`, `remove-parent`) require `--keypair`.
+
+??? note "Example: listing probes on testnet"
+
+    ```bash
+    doublezero-geolocation probe list --env testnet
+    ```
+
+    Returns all registered probes with their codes, public IPs, parent DZDs, and current status.

--- a/docs/contribute-overview.md
+++ b/docs/contribute-overview.md
@@ -135,6 +135,7 @@ New to DoubleZero? Here are the essential terms (see [full Glossary](glossary.md
 | [Requirements & Architecture](contribute.md) | Hardware specs, network architecture, bandwidth options |
 | [Device Provisioning](contribute-provisioning.md) | Step-by-step: keys → repo access → device → links → agents |
 | [Operations](contribute-operations.md) | Agent upgrades, link management, monitoring |
+| [Geoprobe Deployment](contribute-geolocation.md) | Deploying and configuring geoProbe agents for geolocation |
 | [Glossary](glossary.md) | All DoubleZero terminology defined |
 
 ---

--- a/docs/geolocation.md
+++ b/docs/geolocation.md
@@ -23,9 +23,6 @@ flowchart LR
      Probe -- "RTT measurement" --> T
      T -- "response" --> Probe
      Probe -. "signed offset" .-> T
-
-     Ledger[("DoubleZero\nLedger (future)")]
-     Probe -. "signed measurements\n(planned)" .-> Ledger
 ```
 
 The following diagram shows the three probe flow types — Outbound, OutboundIcmp, and Inbound — which differ in how the geoProbe communicates with the target:

--- a/docs/geolocation.md
+++ b/docs/geolocation.md
@@ -21,7 +21,7 @@ flowchart LR
      end
 
      Probe -- "RTT measurement" --> T
-     T -- "response" --> Probe
+     T -- "RTT response" --> Probe
      Probe -. "signed offset" .-> T
 ```
 

--- a/docs/geolocation.md
+++ b/docs/geolocation.md
@@ -1,0 +1,312 @@
+# Geolocation
+
+DoubleZero Geolocation is a service for verifying the physical location of devices using latency measurements. [RTT](glossary.md#rtt-round-trip-time) (round-trip time) measurements between known-location infrastructure and a target device provide cryptographically-signed proof that a device is within a certain distance of a given point. Onchain recording of measurements to the DoubleZero Ledger is planned for a future release.
+
+Use cases include regulatory compliance (e.g., GDPR — proving validators operate within the EU), geographic distribution audits, and any application that needs verifiable proof of where a device is running.
+
+---
+
+## How it works
+
+```mermaid
+flowchart LR
+     subgraph DZ["DoubleZero Network"]
+         DZD["DZD\n(known location)"]
+         Probe["geoProbe\n(bare metal server)"]
+         DZD -- "TWAMP\n(continuous latency)" --> Probe
+     end
+
+     subgraph Target["Target Device"]
+         T["Target\n(validator / server)"]
+     end
+
+     Probe -- "RTT measurement" --> T
+     T -- "response" --> Probe
+     Probe -. "signed offset" .-> T
+
+     Ledger[("DoubleZero\nLedger (future)")]
+     Probe -. "signed measurements\n(planned)" .-> Ledger
+```
+
+The following diagram shows the three probe flow types — Outbound, OutboundIcmp, and Inbound — which differ in how the geoProbe communicates with the target:
+
+```mermaid
+flowchart TB
+    subgraph out["Outbound Flow (TWAMP)"]
+        direction LR
+        P1["geoProbe"] -- "TWAMP probe" --> T1["Target"]
+        T1 -- "TWAMP reply" --> P1
+    end
+
+    subgraph icmp["OutboundIcmp Flow"]
+        direction LR
+        P3["geoProbe"] -- "ICMP Echo Request" --> T3["Target"]
+        T3 -- "ICMP Echo Reply" --> P3
+    end
+
+    subgraph in["Inbound Flow (NAT-friendly)"]
+        direction LR
+        T2["Target"] -- "signed packets" --> P2["geoProbe"]
+        P2 -- "reply" --> T2
+    end
+```
+
+Geolocation uses a three-tier measurement chain:
+
+```
+DZD (known location) ──TWAMP──► geoProbe ──RTT──► Target device
+```
+
+- **[DZD](glossary.md#dzd-doublezero-device) <-> geoProbe**: [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) continuously measures latency between the DoubleZero Device and the probe. DZDs have known, fixed geographic coordinates.
+- **geoProbe <-> Target**: RTT is measured between the probe and the device being located.
+
+Offset results are cryptographically signed. Onchain recording to the DoubleZero Ledger is planned for a future release.
+
+**Important:** Geolocation reports RTT only — not inferred distance or coordinates. A common method would be to divide the RTT by 2, and then multiply by the speed of light through glass to provide a radius around the DZD coordinates that the target is located within. How you interpret RTT (e.g., computing a maximum-distance radius) is up to you.
+
+### Probe flow types
+
+There are three ways a probe can measure a target:
+
+| Flow | Who initiates | Protocol | Use when |
+|------|---------------|----------|----------|
+| **Outbound** | Probe -> Target | [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) | Target has a public IP, open inbound port, and can run a TWAMP reflector |
+| **OutboundIcmp** | Probe -> Target | ICMP echo | Target has a public IP but cannot run a TWAMP reflector (or TWAMP is blocked by firewall) |
+| **Inbound** | Target -> Probe | Signed TWAMP | Target is behind NAT or cannot accept inbound connections |
+
+In all cases, the DZD <-> geoProbe measurement happens the same way. Only the direction and protocol of the geoProbe <-> target communication differs.
+
+### OutboundIcmp
+
+The OutboundIcmp flow uses standard ICMP echo (ping) to measure [RTT](glossary.md#rtt-round-trip-time) to the target. The geoProbe sends ICMP echo requests to the target and measures RTT from the echo reply.
+
+```mermaid
+flowchart LR
+    DZD["DZD"] -- "TWAMP" --> Probe["geoProbe"]
+    Probe -- "ICMP Echo Request" --> Target["Target"]
+    Target -- "ICMP Echo Reply" --> Probe
+    Probe -- "Signed Offset\n(with RTT)" --> Target
+```
+
+Key advantages of OutboundIcmp:
+
+- **No software installation required on the target** — it only needs to respond to ICMP pings
+- Useful when [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) traffic is blocked by firewall rules
+- Works when the target cannot run custom software (e.g., managed infrastructure)
+
+!!! info "Technical Specification"
+    For the full technical specification of the geolocation verification system, including cryptographic signing details and the measurement protocol, see [RFC 16: Geolocation Verification](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc16-geolocation-verification.md).
+
+---
+
+## Prerequisites
+
+### 1. DoubleZero ID with credits
+
+Geolocation users need a funded DoubleZero ID. You do not need to connect to the DoubleZero network (no access pass required), but your key needs credits on the DoubleZero ledger to create a user account and manage targets — each add/remove target operation costs credits.
+
+If you don't have a DoubleZero ID:
+
+```bash
+doublezero keygen
+doublezero address   # get your pubkey
+```
+
+Contact the DoubleZero team with your pubkey to get your ID funded. Fund it to a higher-than-typical amount if you expect to add and remove targets dynamically.
+
+### 2. 2Z token account
+
+You need a [2Z token](glossary.md#2z-token) account. Service fees are deducted from this account on a per-epoch basis.
+
+---
+
+## Installation
+
+```bash
+sudo apt install doublezero-geolocation
+```
+
+This installs two binaries:
+
+- **`doublezero-geolocation`** — CLI for managing users, probes, and targets on the DoubleZero ledger
+- **`doublezero-geoprobe-target-sender`** — runs on the device being measured; used for inbound probe flows
+
+!!! note "Package contents"
+    The `doublezero-geolocation` package provides the CLI for all geolocation management commands (creating users, managing targets, listing probes). Both geolocation **users** and **contributors** use this same package.
+
+---
+
+## Check your balance
+
+```bash
+doublezero balance --env testnet
+```
+
+---
+
+## Setup
+
+### Step 1: Create a geolocation user
+
+```bash
+doublezero-geolocation user create \
+  --env testnet \
+  --code <your-user-code> \
+  --token-account <your-2Z-token-account>
+```
+
+- `--code`: a short, unique identifier for your account (e.g. `myorg`)
+- `--token-account`: the public key of your [2Z token](glossary.md#2z-token) account — service fees are deducted from here
+
+!!! note "Account activation"
+    After creating a user, contact the DoubleZero Foundation to activate your account. Payment status must be marked active before probing begins.
+
+### Step 2: List available probes
+
+```bash
+doublezero-geolocation probe list --env testnet
+```
+
+Note the **code**, **IP address**, and **public key** of the probe you want to use.
+
+### Step 3: Add a target
+
+=== "Outbound (probe sends TWAMP to target)"
+
+    Use this flow if your target has a public IP, an open inbound port, and can run a [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) reflector.
+
+    ```bash
+    doublezero-geolocation user add-target \
+      --env testnet \
+      --user <your-user-code> \
+      --type outbound \
+      --probe <probe-code> \
+      --ip-address <target-public-ip> \
+      --location-offset-port <port>
+    ```
+
+    - `--ip-address`: the public IPv4 address of the target device
+    - `--location-offset-port`: the port on the target that the probe will send measurements to
+
+=== "OutboundIcmp (probe pings target)"
+
+    Use this flow if your target has a public IP but cannot run a TWAMP reflector, or if TWAMP traffic is blocked by firewall. The target only needs to respond to ICMP echo (ping) requests — no additional software required.
+
+    ```bash
+    doublezero-geolocation user add-target \
+      --env testnet \
+      --user <your-user-code> \
+      --type OutboundIcmp \
+      --probe <probe-code> \
+      --ip-address <target-public-ip> \
+      --location-offset-port <port>
+    ```
+
+    - `--ip-address`: the public IPv4 address of the target device
+    - `--location-offset-port`: the port on the target where the probe will send signed LocationOffset results
+
+=== "Inbound (target sends to probe)"
+
+    Use this flow if your target is behind NAT or cannot accept inbound connections.
+
+    ```bash
+    doublezero-geolocation user add-target \
+      --env testnet \
+      --user <your-user-code> \
+      --type inbound \
+      --probe <probe-code> \
+      --target-pk <target-keypair-pubkey>
+    ```
+
+    - `--probe`: the code of the geoProbe that will measure the target (e.g. `ams-tn-gp1`)
+    - `--target-pk`: public key of the keypair the target will use to sign messages — the probe only accepts messages from registered public keys
+
+### Step 3b: Set a result destination (optional)
+
+Configure an alternate `host:port` where composite LocationOffset results are delivered, in addition to each target's location offset port. This is useful for aggregating results from multiple targets to a single endpoint.
+
+```bash
+doublezero-geolocation user set-result-destination \
+  --env testnet \
+  --user <your-user-code> \
+  --destination <host:port>
+```
+
+- `--destination`: a publicly routable IPv4 address or valid domain name with port (e.g., `203.0.113.10:9000` or `results.example.com:9000`). Pass an empty string to clear.
+
+Use `user get` to verify your result destination:
+
+```bash
+doublezero-geolocation user get --env testnet --user <your-user-code>
+```
+
+### Step 4: Run the target application
+
+Both outbound and inbound flows require running an application on the target device. Reference implementations with examples are available in Go and Rust — you can run them directly or use them as a starting point for your own integration.
+
+=== "Outbound"
+
+    For outbound probing, the target device must run a [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) reflector so the geoProbe can measure RTT. Run the target application on the device being measured:
+
+    ```bash
+    doublezero-geoprobe-target-sender \
+      -probe-ip <probe-ip> \
+      -probe-pk <probe-pubkey> \
+      -keypair <path-to-keypair.json>
+    ```
+
+=== "Inbound"
+
+    For inbound probing, the target device must run software that sends signed messages to the probe.
+
+    On the device being measured:
+
+    ```bash
+    doublezero-geoprobe-target-sender \
+      -probe-ip <probe-ip> \
+      -probe-pk <probe-pubkey> \
+      -keypair <path-to-keypair.json>
+    ```
+
+- `-probe-ip`: IP address of the geoProbe (from `probe list`)
+- `-probe-pk`: public key of the geoProbe (from `probe list`)
+- `-keypair`: path to the keypair whose public key was registered as `--target-pk` in Step 3
+
+The target sender uses a two-probe-pair mechanism: it sends two pre-signed [TWAMP](glossary.md#twamp-two-way-active-measurement-protocol) probes in quick succession. The probe's reply to the second packet includes `SinceLastRxNs` — the time between the probe sending reply 0 and receiving probe 1 — which serves as the probe-measured [RTT](glossary.md#rtt-round-trip-time). This paired approach provides an accurate RTT measurement even when the target cannot perform precise kernel-level timestamping.
+
+---
+
+## Command reference
+
+### `doublezero-geolocation user`
+
+| Subcommand | Description |
+|------------|-------------|
+| `create` | Create a new geolocation user account |
+| `get` | Get details of a specific user |
+| `list` | List all geolocation users |
+| `delete` | Delete a user |
+| `add-target` | Add a target to a user |
+| `remove-target` | Remove a target from a user |
+| `set-result-destination` | Set an alternate host:port for offset delivery |
+| `update-payment` | Update payment status (foundation use) |
+
+### `doublezero-geolocation probe`
+
+| Subcommand | Description |
+|------------|-------------|
+| `create` | Register a new geoProbe |
+| `get` | Get details of a specific probe |
+| `list` | List all probes |
+| `update` | Update probe configuration |
+| `delete` | Delete a probe |
+| `add-parent` | Link a DZD as a parent of the probe |
+| `remove-parent` | Remove a parent DZD |
+
+### Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--env` | Network environment: `testnet`, `devnet`, or `mainnet-beta` |
+| `--rpc-url` | Custom Solana RPC endpoint |
+| `--keypair` | Path to signing keypair (required for write operations) |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -134,6 +134,19 @@ A link-state routing protocol used internally by the DoubleZero network. IS-IS m
 
 ---
 
+## Geolocation
+
+### Geolocation
+A DoubleZero service that verifies the physical location of devices using latency measurements. [RTT](#rtt-round-trip-time) measurements between known-location infrastructure ([DZDs](#dzd-doublezero-device)) and target devices provide cryptographically signed proof that a device is within a certain distance of a reference point. Onchain recording of measurements is planned for a future release. See [Geolocation](geolocation.md) for user documentation.
+
+### geoProbe
+A bare metal server that acts as an intermediary for latency measurements in the [Geolocation](#geolocation) system. geoProbes are located within ~1ms of a [DZD](#dzd-doublezero-device), receive signed LocationOffsets from parent DZDs, and measure [RTT](#rtt-round-trip-time) to target devices via [TWAMP](#twamp-two-way-active-measurement-protocol), signed TWAMP, or ICMP echo. Each geoProbe is registered [onchain](#onchain) and linked to one or more parent DZDs. See [Geoprobe Deployment](contribute-geolocation.md) for contributor documentation.
+
+### LocationOffset
+A signed data structure containing a [DZD's](#dzd-doublezero-device) geographic location (latitude and longitude) and a chain of latency relationships between entities (DZD↔Probe or Probe↔Target). LocationOffsets are signed with Ed25519 and sent via UDP through the measurement chain. Composite offsets include references to previous measurements, creating an auditable trail.
+
+---
+
 ## Blockchain & Keys
 
 ### Onchain

--- a/docs/work-plan-165.md
+++ b/docs/work-plan-165.md
@@ -1,0 +1,141 @@
+# Work Plan: Issue #165 — Geolocation Documentation Update
+
+**Revision 4** — Addresses operator feedback: rename contributor doc, mark ledger as future, simplify diagrams, remove Architecture section from contributor doc, add RFC 16 reference to user doc.
+
+## Summary
+
+Issue #165 asks us to update the geolocation documentation. Revisions 1–3 created two documents (`docs/geolocation.md` and `docs/contribute-geoprobe.md`) and integrated them into the site nav. Both documents are now written and committed. Revision 4 addresses the operator's latest round of feedback with five targeted changes to the existing content.
+
+## Changes Required (Revision 4)
+
+### Change 1: Rename `docs/contribute-geoprobe.md` → `docs/contribute-geolocation.md`
+
+Rename the contributor document file and update all references:
+
+- **`docs/contribute-geoprobe.md`** → **`docs/contribute-geolocation.md`** (git mv)
+- **`mkdocs.yml`** line 73: change `contribute-geoprobe.md` → `contribute-geolocation.md`
+- **`docs/contribute-overview.md`**: update any link to `contribute-geoprobe.md` → `contribute-geolocation.md`
+- **`docs/geolocation.md`**: if any cross-references exist to the contributor doc, update them (currently the user doc does not link to the contributor doc, so this may be a no-op)
+
+### Change 2: Mark DZ Ledger writing as a future feature in `docs/geolocation.md`
+
+The current first diagram (lines 11–28) shows the probe writing signed measurements onchain to the "DoubleZero Ledger". The intro text (line 3) says "onchain proof" and line 66 says "All measurements are cryptographically signed and recorded onchain." These need to be updated to indicate that onchain ledger recording is a **planned future feature**, not currently implemented.
+
+Specific edits:
+
+- **Line 3 (intro paragraph)**: Change "cryptographically-signed, onchain proof" to indicate the measurements are cryptographically signed, with onchain recording planned as a future feature.
+- **First mermaid diagram (lines 11–28)**: Modify the `Ledger` node and its connection to indicate it is a future feature. Options:
+  - Add a dashed/dotted line style to the Probe→Ledger connection (mermaid supports `-.->` for dashed arrows)
+  - Label the Ledger node or connection as "(future)"
+  - Or remove the Ledger node entirely and add a text note below the diagram
+  
+  Recommended approach: keep the Ledger node but use a dashed arrow and "(future)" label so users understand the planned architecture:
+  ```
+  Probe -. "signed measurements\n(future)" .-> Ledger
+  ```
+
+- **Line 66**: Change "All measurements are cryptographically signed and recorded onchain." to note that measurements are cryptographically signed, and onchain recording is planned for a future release.
+
+### Change 3: Remove DZD→Probe connection from 2nd diagram in `docs/geolocation.md`
+
+The second mermaid diagram (lines 32–55) currently has a top-level DZD node connected via TWAMP to the Probe:
+
+```mermaid
+DZD["DZD (known location)"]
+Probe["geoProbe"]
+DZD -- "TWAMP" --> Probe
+```
+
+Per operator feedback, remove these three lines (and any connecting edges) so the second diagram only shows the three flow-type subgraphs (Outbound, OutboundIcmp, Inbound) without the DZD→Probe prefix. The DZD→Probe relationship is already explained in the first diagram and in prose — showing it again in the flow-type comparison diagram is redundant.
+
+The resulting diagram should be:
+
+```mermaid
+flowchart TB
+    subgraph out["Outbound Flow (TWAMP)"]
+        direction LR
+        P1["geoProbe"] -- "TWAMP probe" --> T1["Target"]
+        T1 -- "TWAMP reply" --> P1
+    end
+
+    subgraph icmp["OutboundIcmp Flow"]
+        direction LR
+        P3["geoProbe"] -- "ICMP Echo Request" --> T3["Target"]
+        T3 -- "ICMP Echo Reply" --> P3
+    end
+
+    subgraph in["Inbound Flow (NAT-friendly)"]
+        direction LR
+        T2["Target"] -- "signed packets" --> P2["geoProbe"]
+        P2 -- "reply" --> T2
+    end
+```
+
+### Change 4: Remove Architecture section from `docs/contribute-geolocation.md`
+
+The Architecture section (current lines 9–47 in `contribute-geoprobe.md`) contains the three RFC 16 diagrams (outbound flow, inbound flow, onchain account structure). Per operator feedback, remove this entire section. The existing intro paragraph already links to `geolocation.md` ("the bare metal servers that perform latency measurements for the DoubleZero [Geolocation](geolocation.md) service"), which serves as sufficient cross-reference.
+
+Optionally, add a brief sentence after the intro directing readers to the user doc for architecture context, e.g.: "For an overview of the geolocation architecture and measurement flows, see the [Geolocation user guide](geolocation.md)." — but the operator noted the reference already exists, so the existing link in the first paragraph may suffice.
+
+Lines to remove: everything from `## Architecture` through the `---` separator before `## Prerequisites` (approximately lines 9–48 of the current file).
+
+### Change 5: Add RFC 16 reference in `docs/geolocation.md`
+
+Add a reference to [RFC 16](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc16-geolocation-verification.md) in the user-facing geolocation doc. This gives users a pointer to the full technical specification.
+
+Recommended placement: add an admonition or note at the end of the "How it works" section (after the probe flow types subsection, around line 98), similar to the one that was in the contributor doc:
+
+```markdown
+!!! info "Technical Specification"
+    For the full technical specification of the geolocation verification system, including cryptographic signing details and the measurement protocol, see [RFC 16: Geolocation Verification](https://github.com/malbeclabs/doublezero/blob/main/rfcs/rfc16-geolocation-verification.md).
+```
+
+## Files to Change
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/contribute-geoprobe.md` | **Rename** → `docs/contribute-geolocation.md` | Rename file per operator feedback |
+| `docs/contribute-geolocation.md` | **Modify** | Remove Architecture section (lines 9–48); the intro already links to `geolocation.md` |
+| `docs/geolocation.md` | **Modify** | (a) Mark ledger writing as future in intro, diagram, and prose; (b) Remove DZD→Probe from 2nd diagram; (c) Add RFC 16 reference |
+| `mkdocs.yml` | **Modify** | Update nav: `contribute-geoprobe.md` → `contribute-geolocation.md` |
+| `docs/contribute-overview.md` | **Modify** | Update link from `contribute-geoprobe.md` → `contribute-geolocation.md` (if present) |
+
+## Implementation Order
+
+1. `git mv docs/contribute-geoprobe.md docs/contribute-geolocation.md`
+2. Edit `docs/contribute-geolocation.md` — remove Architecture section
+3. Edit `docs/geolocation.md` — all three sub-changes (ledger as future, simplify 2nd diagram, add RFC 16 ref)
+4. Edit `mkdocs.yml` — update nav reference
+5. Edit `docs/contribute-overview.md` — update link if present
+6. Verify with `mkdocs serve` (or `mkdocs build`) that all pages render and links resolve
+
+## Risks & Considerations
+
+1. **Dashed arrows in mermaid**: Mermaid supports `-. "label" .->` for dashed arrows. Need to verify this renders correctly with mkdocs-material's mermaid integration (pymdownx.superfences). If dashed arrows don't render well, fall back to adding "(future)" text annotation below the diagram instead.
+
+2. **Translation files**: Renaming `contribute-geoprobe.md` to `contribute-geolocation.md` may affect translated versions (e.g., `contribute-geoprobe.es.md`). Check whether translated versions exist and rename them accordingly, or let the translation workflow regenerate them.
+
+3. **Existing links**: Any other docs that link to `contribute-geoprobe.md` (the glossary, other contributor docs) need updating. A grep for `contribute-geoprobe` across the docs directory will catch these.
+
+## Testing Strategy
+
+1. **Link validation**: `grep -r "contribute-geoprobe" docs/` to ensure no stale references remain after rename
+2. **Build check**: `mkdocs build` to verify no broken links or rendering issues
+3. **Diagram rendering**: Confirm the modified mermaid diagrams (dashed ledger arrow, simplified flow-type diagram) render correctly
+4. **Nav verification**: Confirm the renamed file appears correctly in the Contributors nav section
+
+## Estimated Scope
+
+~5 files modified, ~50 lines changed (mostly deletions from removing the Architecture section and simplifying diagrams). All changes are documentation — **0 lines** count against the 500-line threshold.
+
+## Resolved Questions (Cumulative)
+
+1. **Nav placement**: Resolved (Rev 3) — `geolocation.md` under Users, contributor doc under Contributors.
+2. **Geoprobe-agent package name**: Resolved (Rev 1) — `doublezero-geoprobe-agent`.
+3. **OutboundIcmp coverage**: Resolved (Rev 1) — fully documented with subsection, diagram, and examples.
+4. **RFC architecture diagrams**: Resolved (Rev 2, **updated Rev 4**) — Diagrams removed from contributor doc per operator feedback. RFC 16 reference added to user doc instead.
+5. **DZD telemetry agent version**: Resolved (Rev 2) — Warning admonition in contributor doc Prerequisites.
+6. **Contributor doc filename**: Resolved (Rev 4) — Renamed from `contribute-geoprobe.md` to `contribute-geolocation.md`.
+7. **DZ Ledger onchain recording**: Resolved (Rev 4) — Marked as a future feature in diagrams and prose in `geolocation.md`.
+8. **2nd diagram DZD→Probe connection**: Resolved (Rev 4) — Removed per operator feedback; the flow-type comparison diagram only shows the three geoProbe↔Target flows.
+9. **RFC 16 reference placement**: Resolved (Rev 4) — Added as an `!!! info` admonition at the end of the "How it works" section in `geolocation.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,12 +64,14 @@ nav:
       - Shelby:
         - Shelby Connection: Shelby Permissioned Connection.md
       - New Tenant: New Tenant.md
+    - Geolocation: geolocation.md
   - Contributors:
     - Overview: contribute-overview.md
     - Requirements & Architecture: contribute.md
     - Device Provisioning: contribute-provisioning.md
     - Operations: contribute-operations.md
     - OPS Management: contribute-ops-management.md
+    - Geolocation: contribute-geolocation.md
   - Architecture: architecture.md
   - Glossary: glossary.md
 markdown_extensions:
@@ -79,6 +81,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.tasklist:
       custom_checkbox: true
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
         - Permissioned Connection: Permissioned Connection.md
         - Validator Multicast Connection: Validator Multicast Connection.md
         - Other Multicast Connection: Other Multicast Connection.md
+        - Edge Subscriber Connection: Edge Subscriber Connection.md
         - Troubleshooting: troubleshooting.md
       - Shelby:
         - Shelby Connection: Shelby Permissioned Connection.md


### PR DESCRIPTION
## Summary

Fixes #165

- Add **geolocation user guide** (`docs/geolocation.md`) covering GeoProbe overview, prerequisites, connecting via CLI/UI, monitoring, and troubleshooting
- Add **GeoProbe contributor guide** (`docs/contribute-geoprobe.md`) with architecture, development setup, testing, and deployment procedures
- Update **contributor overview** (`docs/contribute-overview.md`) to link the new GeoProbe contributor page
- Add geolocation-related terms to the **glossary** (`docs/glossary.md`)
- Update **mkdocs.yml** navigation to include the new pages

## Test plan
- [ ] Verify `mkdocs serve` builds without errors
- [ ] Confirm new pages render correctly and navigation links work
- [ ] Check glossary terms appear on the glossary page
