### PR TITLE
translation github action fix

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,22 +1,32 @@
 name: Auto-translate docs
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - 'docs/**.md'
+
+concurrency:
+  group: translate-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   translate:
     runs-on: ubuntu-latest
-    # Prevent infinite loop: skip when the bot itself pushes translations
-    if: github.event.head_commit.author.name != 'github-actions[bot]'
-    permissions:
-      contents: write
+    # Skip the bot's own commits (prevents loops) and fork PRs (no secret access).
+    if: >
+      github.actor != 'github-actions[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
@@ -27,7 +37,7 @@ jobs:
       - name: Find changed source docs
         id: changed
         run: |
-          BASE=$(git rev-parse HEAD~1 2>/dev/null || git hash-object -t tree /dev/null)
+          BASE="${{ github.event.pull_request.base.sha }}"
           # Only source .md files — exclude already-translated ones (e.g. index.es.md)
           CHANGED=$(git diff --name-only "$BASE" HEAD -- docs/ \
             | grep '\.md$' \
@@ -49,11 +59,15 @@ jobs:
           LANGUAGES: "zh,ja,ko,pt,es,fr,it"
         run: python scripts/translate.py
 
-      - name: Commit translations
+      - name: Commit translations to PR branch
         if: steps.changed.outputs.files != ''
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/
-          git diff --cached --quiet || git commit -m "chore: auto-translate docs"
-          git push
+          if git diff --cached --quiet; then
+            echo "No translation changes."
+            exit 0
+          fi
+          git commit -m "chore: auto-translate docs"
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
## Summary

- Every Auto-translate run since 2026-03-31 has failed at the final `git push` step — `main` is branch-protected (`GH013: Changes must be made through a pull request`), so the bot can't push translations directly. Four PRs of doc edits (#164, #168, #169, #170) merged without their translations.
- Switches the trigger from `push: main` to `pull_request`, so translations land *inside* the same PR as the English changes and never touch the protected branch.
- Adds a concurrency group, a fork-PR guard, and a loop guard that works for `pull_request` events (the old `head_commit.author` check is null on PR events).

## What changed in `.github/workflows/translate.yml`

- Trigger: `push: main` → `pull_request` (opened, synchronize, reopened) on `docs/**.md`
- Checkout: `ref: ${{ github.head_ref }}` + `fetch-depth: 0` to access the PR base SHA
- Diff base: `HEAD~1` → `${{ github.event.pull_request.base.sha }}`
- Loop guard: `github.event.head_commit.author.name` → `github.actor`
- Added: `github.event.pull_request.head.repo.full_name == github.repository` to skip fork PRs (secrets aren't exposed there)
- Added: `concurrency: { group: translate-${{ github.head_ref }}, cancel-in-progress: true }`
- Final step pushes to `HEAD:${{ github.head_ref }}` instead of `main`

`scripts/translate.py` is unchanged — it's already env-driven.

## Test plan

The workflow's `paths:` filter is `docs/**.md`, so this PR won't trigger it. After merge, the first real test is the next PR that touches a doc file.

- [ ] Merge this PR
- [ ] Open a follow-up PR with a one-line edit to any `docs/*.md` file
- [ ] Confirm the "Auto-translate docs" check runs (~7 min for 1 source file × 7 languages)
- [ ] Confirm a `chore: auto-translate docs` commit by `github-actions[bot]` lands on the PR branch with the `.zh/.ja/.ko/.pt/.es/.fr/.it` files
- [ ] Confirm the bot's commit does NOT re-trigger the workflow (`gh run list --workflow=translate.yml` should show only one run for the PR)
- [ ] Push a second commit within ~30s and confirm the first run is cancelled (concurrency)

## Out of scope

- Backlog: `architecture.md` (stale translations) and `contribute-ops-management.md` (no translations) will self-heal next time someone edits them.
- No `workflow_dispatch` manual trigger added — can be retrofitted later if catch-up becomes painful.
- Fork PRs are skipped, not supported via `pull_request_target` (security risk for an internal docs repo).