### PR TITLE
docs: register the Kalshi runbook in the MCP index

### DIFF
--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -22,3 +22,4 @@ To register a runbook, add a list item under **Index** in this shape:
 - `solana-ibrl` — [Connect validator (IBRL Mainnet)](solana-ibrl-runbook.md)
 - `solana-shreds-publisher` — [Publish shreds (Edge)](solana-shreds-publisher-runbook.md)
 - `solana-shreds` — [Subscribe to shreds (Edge)](solana-shreds-runbook.md)
+- `kalshi` — [Kalshi + Edge Connect](kalshi-runbook.md)


### PR DESCRIPTION
Adds `kalshi` to `docs/runbooks.md` so the MCP can list and load the Kalshi Edge Connect runbook.