### PR TITLE
docs(kalshi): document Edge Connect teardown in the runbook

### DIFF
--- a/docs/kalshi-runbook.md
+++ b/docs/kalshi-runbook.md
@@ -192,6 +192,7 @@ Replace the group IP with the row you subscribed.
 6. **Installer exit 0 ≠ tunnel up.** Missing access pass or credits: the script continues and still prints Done / a WebSocket URL. Trust `doublezero status`, not the installer footer.
 7. **Feed metro ≠ closest device.** Edge Connect attaches to the metro that serves the purchased feed. Forcing `--device` at the lowest-latency site fails if that metro does not serve the feed. The constraint is the **device**, not where the host sits (a host far from the serving metro can still attach to that device).
 8. **Stale `doublezero1`.** `tunnel already exists`, mixed `169.254.x` addresses, or BGP TCP never establishing to the inner peer → disconnect, delete the iface, connect again. Do not stack a second GRE on a dirty iface.
+9. **Never `docker rm -f` / `docker kill` the bridge.** `SIGKILL` skips the disconnect the entrypoint runs on `docker stop`, orphaning the onchain session and `doublezero1` in the host netns — gotcha 8, self-inflicted. See [Teardown](#teardown).
 
 ---
 
@@ -205,6 +206,31 @@ Replace the group IP with the row you subscribed.
 ```
 
 Full field list: [PROTOCOL.md](https://github.com/malbeclabs/doublezero-edge-connect/blob/main/PROTOCOL.md).
+
+---
+
+## Teardown
+
+`docker stop` **is** the uninstall. The entrypoint stays PID 1 so its `TERM` trap can run a bounded `doublezero disconnect` while the daemon is still up, releasing the onchain session, the GRE tunnel and its routes. The installer creates the container with `--stop-timeout 60`, which is what gives that disconnect room to finish.
+
+```bash
+docker stop doublezero-edge-connect
+docker rm doublezero-edge-connect
+```
+
+Confirm the tunnel actually came down. The bridge ran with `--network host`, so a disconnect that did not happen leaves the iface orphaned on the host. Expect `Device "doublezero1" does not exist.`:
+
+```bash
+ip link show doublezero1
+```
+
+If it is still there, the previous session was not released — delete the iface and treat the onchain session as still held.
+
+The `doublezero-edge` CLI (if you installed it) versions independently of the bridge and is removed separately. Neither removal touches the Cloudsmith repo config, which is a normal `apt`/`dnf` source file:
+
+```bash
+sudo apt remove doublezero-edge   # or: sudo dnf remove doublezero-edge
+```
 
 ---
 


### PR DESCRIPTION
The Kalshi runbook ends at "Confirm data path" with no removal path, so the only uninstall guidance for Edge Connect lives in the bridge repo's README. An agent driving this runbook via `get_onboarding_runbook` has nothing to offer a user who asks how to undo it.

Adds a `## Teardown` section and one gotcha.

The part worth reviewing is the correctness claim, not the prose. `docker stop` **is** the uninstall: the entrypoint stays PID 1 specifically so its `TERM` trap can run a bounded `doublezero disconnect` while the daemon is still up, and the installer sets `--stop-timeout 60` to give it room. So a manual `doublezero disconnect` first is redundant — but `docker rm -f` or `docker kill` bypasses the trap and orphans the onchain session and `doublezero1` in the host netns. That is gotcha 8 ("Stale `doublezero1`") arriving self-inflicted, and it was documented nowhere user-facing; `connect.sh` warns about it only in its own reinstall path. The verification step uses `ip link show doublezero1` rather than `doublezero status`, since the latter is only reachable through `docker exec` and the container is gone by then.

Sources: `docker-entrypoint.sh` (the trap and its `SIGNALED`/`dz_connected` guards), `scripts/connect.sh` (`--stop-timeout 60`, and the orphaned-iface warning it emits after a failed graceful stop).

## Blocker — this page is already truncated

Not introduced here, but it makes this PR ineffective on its own. The MCP fetches runbooks through `docsfetch`, which hard-cuts every page at `MaxPageBytes = 10000`. This page is **11,086 bytes on `main`**, so the model already never sees the tail — the cut lands mid-sentence in gotcha 7, dropping gotcha 8, the consumer sketch and See also. The section added here sits past that cut.

It is systemic, not specific to this page. 9 of the 20 MCP-served pages are over the limit: `troubleshooting` at 21,033 bytes loses 52% of itself, `contribute` 43%, and `kalshi`, `contribute-operations`, `geolocation`, `glossary`, `setup` and `multicast-admin` are all cut. That is worth its own issue against `lake`.

So: merge this for the content and the docs site, but the MCP will not serve it until `MaxPageBytes` is raised or these pages are trimmed. Happy to trim this page under 10,000 in this PR instead if that is the call.
